### PR TITLE
feat: return Claim from `ContentClaimsLocator#locate`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2.2.3
+        uses: pnpm/action-setup@v4.0.0
         with:
           version: 8
       - name: Setup Node

--- a/src/api.ts
+++ b/src/api.ts
@@ -30,7 +30,7 @@ export interface Blob {
 export interface Location {
   digest: MultihashDigest
   site: Site[]
-  claim: Claim
+  claims: Claim[]
 }
 
 export interface Site {

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,7 @@
 import { ByteView, MultihashDigest } from 'multiformats'
 import { Failure, Result, URI } from '@ucanto/interface'
 import { Range } from 'multipart-byte-range'
+import { Claim } from '@web3-storage/content-claims/client/api'
 
 export { ByteView, MultihashDigest } from 'multiformats'
 export { Failure, Result, URI } from '@ucanto/interface'
@@ -29,6 +30,7 @@ export interface Blob {
 export interface Location {
   digest: MultihashDigest
   site: Site[]
+  claim: Claim
 }
 
 export interface Site {

--- a/src/locator/content-claims.js
+++ b/src/locator/content-claims.js
@@ -76,6 +76,7 @@ export class ContentClaimsLocator {
             location: claim.location.map(l => new URL(l)),
             range: { offset: claim.range.offset, length: claim.range.length }
           })
+          location.claims.push(claim)
         } else {
           this.#cache.set(digest, {
             digest,
@@ -83,7 +84,7 @@ export class ContentClaimsLocator {
               location: claim.location.map(l => new URL(l)),
               range: { offset: claim.range.offset, length: claim.range.length }
             }],
-            claim
+            claims: [claim]
           })
         }
       }
@@ -122,7 +123,7 @@ export class ContentClaimsLocator {
                   length: s.range.offset + pos[1]
                 }
               })),
-              claim
+              claims: [claim]
             })
           }
         }))

--- a/src/locator/content-claims.js
+++ b/src/locator/content-claims.js
@@ -12,6 +12,11 @@ import { NotFoundError } from '../lib.js'
 /** @implements {API.Locator} */
 export class ContentClaimsLocator {
   /**
+   * Cached content claims.
+   * @type {Map<API.MultihashDigest, import('@web3-storage/content-claims/client/api').Claim[]>}
+   */
+  claims
+  /**
    * Cached location entries.
    * @type {Map<API.MultihashDigest, API.Location>}
    */
@@ -39,6 +44,7 @@ export class ContentClaimsLocator {
    * @param {{ serviceURL?: URL }} [options]
    */
   constructor (options) {
+    this.claims = new DigestMap()
     this.#cache = new DigestMap()
     this.#claimFetched = new DigestMap()
     this.#serviceURL = options?.serviceURL
@@ -126,6 +132,7 @@ export class ContentClaimsLocator {
         }))
       }
     }
+    this.claims.set(digest, claims)
     this.#claimFetched.set(digest, true)
   }
 }

--- a/src/locator/content-claims.js
+++ b/src/locator/content-claims.js
@@ -12,11 +12,6 @@ import { NotFoundError } from '../lib.js'
 /** @implements {API.Locator} */
 export class ContentClaimsLocator {
   /**
-   * Cached content claims.
-   * @type {Map<API.MultihashDigest, import('@web3-storage/content-claims/client/api').Claim[]>}
-   */
-  claims
-  /**
    * Cached location entries.
    * @type {Map<API.MultihashDigest, API.Location>}
    */
@@ -44,7 +39,6 @@ export class ContentClaimsLocator {
    * @param {{ serviceURL?: URL }} [options]
    */
   constructor (options) {
-    this.claims = new DigestMap()
     this.#cache = new DigestMap()
     this.#claimFetched = new DigestMap()
     this.#serviceURL = options?.serviceURL
@@ -88,7 +82,8 @@ export class ContentClaimsLocator {
             site: [{
               location: claim.location.map(l => new URL(l)),
               range: { offset: claim.range.offset, length: claim.range.length }
-            }]
+            }],
+            claim
           })
         }
       }
@@ -126,13 +121,13 @@ export class ContentClaimsLocator {
                   offset: s.range.offset + pos[0],
                   length: s.range.offset + pos[1]
                 }
-              }))
+              })),
+              claim
             })
           }
         }))
       }
     }
-    this.claims.set(digest, claims)
     this.#claimFetched.set(digest, true)
   }
 }

--- a/test/helpers/context.js
+++ b/test/helpers/context.js
@@ -1,0 +1,8 @@
+import { withBucketServer } from './bucket.js'
+import { withClaimsServer } from './claims.js'
+
+/**
+ * @typedef {import('./helpers/bucket.js').BucketServerContext & import('./helpers/claims.js').ClaimsServerContext} Context
+ * @param {(assert: import('entail').assert, ctx: Context) => unknown} testfn
+ */
+export const withContext = testfn => withBucketServer(withClaimsServer(testfn))

--- a/test/helpers/random.js
+++ b/test/helpers/random.js
@@ -1,3 +1,12 @@
+import { sha256 } from 'multiformats/hashes/sha2'
+import { fromShardArchives } from '@web3-storage/blob-index/util'
+import * as UnixFS from '@ipld/unixfs'
+import { CARWriterStream } from 'carstream'
+import * as ed25519 from '@ucanto/principal/ed25519'
+import { concat } from './stream.js'
+import { settings } from './unixfs.js'
+import { contentKey } from './bucket.js'
+import { generateLocationClaims } from './claims.js'
 import { webcrypto } from 'node:crypto'
 
 /** @param {number} size */
@@ -14,3 +23,40 @@ export const randomBytes = async (size) => {
 
 /** @param {number} max */
 export const randomInt = (max) => Math.floor(Math.random() * max)
+
+/**
+ *
+ * @param {import('./helpers/context.js').Context} ctx
+ * @returns {Promise<{root: Link.Link, fileBytes: Uint8Array}>}
+ */
+export async function createRandomFile (ctx) {
+  const fileBytes = await randomBytes(10 * 1024 * 1024)
+
+  const { readable, writable } = new TransformStream({}, UnixFS.withCapacity(1048576 * 32))
+  const writer = UnixFS.createWriter({ writable, settings })
+
+  const [root, carBytes] = await Promise.all([
+    (async () => {
+      const file = UnixFS.createFileWriter(writer)
+      file.write(fileBytes)
+      const { cid } = await file.close()
+      writer.close()
+      return cid
+    })(),
+    concat(readable.pipeThrough(new CARWriterStream()))
+  ])
+  const carDigest = await sha256.digest(carBytes)
+
+  ctx.bucket.put(contentKey(carDigest), carBytes)
+
+  const signer = await ed25519.generate()
+  const index = await fromShardArchives(root, [carBytes])
+  const claims = await generateLocationClaims(signer, new URL(contentKey(carDigest), ctx.bucketURL), index)
+  for (const claim of claims) {
+    ctx.claimsStore.put(claim)
+  }
+  return {
+    root,
+    fileBytes
+  }
+}

--- a/test/locator.spec.js
+++ b/test/locator.spec.js
@@ -1,0 +1,14 @@
+import * as ContentClaimsLocator from '../src/locator/content-claims.js'
+import { withContext } from './helpers/context.js'
+import { createRandomFile } from './helpers/random.js'
+
+export const testLocator = {
+  'it should return claims from ContentClaimsLocator#locate': withContext(async (/** @type {import('entail').assert} assert */ assert, ctx) => {
+    const { root } = await createRandomFile(ctx)
+    const locator = ContentClaimsLocator.create({ serviceURL: ctx.claimsURL })
+    const result = await locator.locate(root.multihash)
+    assert.ok(result.ok)
+    const location = result.ok
+    assert.equal(location.claims.length, 1)
+  })
+}


### PR DESCRIPTION
Return underlying `Claim`  with `Location` - I made `Claim` mandatory and it didn't seem to break anything, but I'm not sure if there are cases where we might want to return `Location`s without including a `Claim` - open to making this optional!