### PR TITLE
build: Don't (re)specify pnpm version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,6 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - name: Setup pnpm
         uses: pnpm/action-setup@v4.0.0
-        with:
-          version: 9
         if: ${{ steps.release.outputs.release_created }}
       - name: Setup Node
         uses: actions/setup-node@v3


### PR DESCRIPTION
It's the `packageManager` in `package.json` now.