### PR TITLE
feat(fetcher): first step at optimization

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "multipart-byte-range": "^3.0.1",
     "p-defer": "^4.0.1",
     "p-queue": "^8.0.1",
+    "uint8arraylist": "^2.4.8",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "@web3-storage/blob-index": "^1.0.2",
     "@web3-storage/content-claims": "^5.1.0",
     "multiformats": "^13.1.0",
-    "multipart-byte-range": "^3.0.1",
     "p-defer": "^4.0.1",
     "p-queue": "^8.0.1",
     "uint8arraylist": "^2.4.8",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "@cloudflare/workers-types": "^4.20241022.0",
     "@ipld/dag-ucan": "^3.4.0",
+    "@opentelemetry/api": "^1.9.0",
     "@storacha/indexing-service-client": "^2.0.0",
     "@ucanto/interface": "^10.0.1",
     "@web3-storage/blob-index": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -65,9 +65,9 @@
     "@web3-storage/blob-index": "^1.0.2",
     "@web3-storage/content-claims": "^5.1.0",
     "multiformats": "^13.1.0",
+    "multipart-byte-range": "^3.0.1",
     "p-defer": "^4.0.1",
     "p-queue": "^8.0.1",
-    "uint8arraylist": "^2.4.8",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@ipld/dag-ucan':
         specifier: ^3.4.0
         version: 3.4.0
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
       '@storacha/indexing-service-client':
         specifier: ^2.0.0
         version: 2.0.0
@@ -184,6 +187,10 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
   '@perma/map@1.0.3':
     resolution: {integrity: sha512-Bf5njk0fnJGTFE2ETntq0N1oJ6YdCPIpTDn3R3KYZJQdeYSOCNL7mBrFlGnbqav8YQhJA/p81pvHINX9vAtHkQ==}
@@ -1643,6 +1650,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
+
+  '@opentelemetry/api@1.9.0': {}
 
   '@perma/map@1.0.3':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       p-queue:
         specifier: ^8.0.1
         version: 8.0.1
+      uint8arraylist:
+        specifier: ^2.4.8
+        version: 2.4.8
       zod:
         specifier: ^3.23.8
         version: 3.23.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,15 +32,15 @@ importers:
       multiformats:
         specifier: ^13.1.0
         version: 13.1.0
+      multipart-byte-range:
+        specifier: ^3.0.1
+        version: 3.0.1
       p-defer:
         specifier: ^4.0.1
         version: 4.0.1
       p-queue:
         specifier: ^8.0.1
         version: 8.0.1
-      uint8arraylist:
-        specifier: ^2.4.8
-        version: 2.4.8
       zod:
         specifier: ^3.23.8
         version: 3.23.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       multiformats:
         specifier: ^13.1.0
         version: 13.1.0
-      multipart-byte-range:
-        specifier: ^3.0.1
-        version: 3.0.1
       p-defer:
         specifier: ^4.0.1
         version: 4.0.1

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,70 +1,11 @@
 import { ByteView, MultihashDigest } from 'multiformats'
 import { Failure, Result, URI, DID } from '@ucanto/interface'
 import { QueryError } from '@storacha/indexing-service-client/api'
+import { Range } from 'multipart-byte-range'
 
 export { ByteView, MultihashDigest } from 'multiformats'
 export { Failure, Result, URI, DID, Principal } from '@ucanto/interface'
-
-/**
- * An absolute byte range to extract - always an array of two values
- * corresponding to the first and last bytes (both inclusive). e.g.
- * 
- * ```
- * [100, 200]
- * ```
- */
-export type AbsoluteRange = [first: number, last: number]
-
-/**
- * A suffix byte range - always an array of one value corresponding to the
- * first byte to start extraction from (inclusive). e.g.
- * 
- * ```
- * [900]
- * ```
- * 
- * If it is unknown how large a resource is, the last `n` bytes
- * can be requested by specifying a negative value:
- * 
- * ```
- * [-100]
- * ```
- */
-export type SuffixRange = [first: number]
-
-/**
- * Byte range to extract - an array of one or two values corresponding to the
- * first and last bytes (both inclusive). e.g.
- * 
- * ```
- * [100, 200]
- * ```
- * 
- * Omitting the second value requests all remaining bytes of the resource. e.g.
- * 
- * ```
- * [900]
- * ```
- * 
- * Alternatively, if it's unknown how large a resource is, the last `n` bytes
- * can be requested by specifying a negative value:
- * 
- * ```
- * [-100]
- * ```
- */
-export type Range = AbsoluteRange | SuffixRange
-
-export type ByteGetter = (range: AbsoluteRange) => Promise<ReadableStream<Uint8Array>>
-
-export interface EncoderOptions {
-  /** Mime type of each part. */
-  contentType?: string
-  /** Total size of the object in bytes. */
-  totalSize?: number
-  /** Stream queuing strategy. */
-  strategy?: QueuingStrategy<Uint8Array>
-}
+export { Range, SuffixRange, AbsoluteRange } from 'multipart-byte-range'
 
 export interface Abortable {
   signal: AbortSignal

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,11 +1,70 @@
 import { ByteView, MultihashDigest } from 'multiformats'
 import { Failure, Result, URI, DID } from '@ucanto/interface'
-import { Range } from 'multipart-byte-range'
 import { QueryError } from '@storacha/indexing-service-client/api'
 
 export { ByteView, MultihashDigest } from 'multiformats'
 export { Failure, Result, URI, DID, Principal } from '@ucanto/interface'
-export { Range, SuffixRange, AbsoluteRange } from 'multipart-byte-range'
+
+/**
+ * An absolute byte range to extract - always an array of two values
+ * corresponding to the first and last bytes (both inclusive). e.g.
+ * 
+ * ```
+ * [100, 200]
+ * ```
+ */
+export type AbsoluteRange = [first: number, last: number]
+
+/**
+ * A suffix byte range - always an array of one value corresponding to the
+ * first byte to start extraction from (inclusive). e.g.
+ * 
+ * ```
+ * [900]
+ * ```
+ * 
+ * If it is unknown how large a resource is, the last `n` bytes
+ * can be requested by specifying a negative value:
+ * 
+ * ```
+ * [-100]
+ * ```
+ */
+export type SuffixRange = [first: number]
+
+/**
+ * Byte range to extract - an array of one or two values corresponding to the
+ * first and last bytes (both inclusive). e.g.
+ * 
+ * ```
+ * [100, 200]
+ * ```
+ * 
+ * Omitting the second value requests all remaining bytes of the resource. e.g.
+ * 
+ * ```
+ * [900]
+ * ```
+ * 
+ * Alternatively, if it's unknown how large a resource is, the last `n` bytes
+ * can be requested by specifying a negative value:
+ * 
+ * ```
+ * [-100]
+ * ```
+ */
+export type Range = AbsoluteRange | SuffixRange
+
+export type ByteGetter = (range: AbsoluteRange) => Promise<ReadableStream<Uint8Array>>
+
+export interface EncoderOptions {
+  /** Mime type of each part. */
+  contentType?: string
+  /** Total size of the object in bytes. */
+  totalSize?: number
+  /** Stream queuing strategy. */
+  strategy?: QueuingStrategy<Uint8Array>
+}
 
 export interface Abortable {
   signal: AbortSignal

--- a/src/fetcher/batching.js
+++ b/src/fetcher/batching.js
@@ -157,7 +157,7 @@ class BatchingFetcher {
  */
 export const create = (locator) => new BatchingFetcher(locator)
 
-/** @typedef {{range: import('multipart-byte-range').AbsoluteRange, digest: API.MultihashDigest, orig: API.Range | undefined}} ResolvedRange */
+/** @typedef {{range: API.AbsoluteRange, digest: API.MultihashDigest, orig: API.Range | undefined}} ResolvedRange */
 
 /**
  * Fetch blobs from the passed locations. The locations MUST share a common
@@ -188,7 +188,7 @@ export const fetchBlobs = withResultSpan('fetchBlobs',
         let found = false
         for (const l of s.location) {
           if (l.toString() === url.toString()) {
-          /** @type {import('multipart-byte-range').AbsoluteRange} */
+          /** @type {API.AbsoluteRange} */
             let resolvedRange = [s.range.offset, s.range.offset + s.range.length - 1]
             if (range) {
               const relRange = resolveRange(range, s.range.length)

--- a/src/fetcher/lib.js
+++ b/src/fetcher/lib.js
@@ -1,7 +1,7 @@
 /**
- * @param {import('multipart-byte-range').Range} range
+ * @param {import('../api.js').Range} range
  * @param {number} totalSize
- * @returns {import('multipart-byte-range').AbsoluteRange}
+ * @returns {import('../api.js').AbsoluteRange}
  */
 export const resolveRange = (range, totalSize) => {
   let last = range[1]

--- a/src/fetcher/simple.js
+++ b/src/fetcher/simple.js
@@ -2,6 +2,7 @@
 import * as API from '../api.js'
 import { resolveRange } from './lib.js'
 import { NetworkError, NotFoundError } from '../lib.js'
+import { withResultSpan } from '../tracing/tracing.js'
 
 /** @implements {API.Fetcher} */
 class SimpleFetcher {
@@ -30,36 +31,39 @@ class SimpleFetcher {
  */
 export const create = (locator) => new SimpleFetcher(locator)
 
-/**
+export const fetchBlob = withResultSpan('fetchBlob',
+  /**
  * Fetch a blob from the passed location.
  * @param {API.Location} location
  * @param {API.Range} [range]
  */
-export const fetchBlob = async (location, range) => {
-  let networkError
-  for (const site of location.site) {
-    for (const url of site.location) {
-      let resolvedRange = [site.range.offset, site.range.offset + site.range.length - 1]
-      if (range) {
-        const relRange = resolveRange(range, site.range.length)
-        resolvedRange = [site.range.offset + relRange[0], site.range.offset + relRange[1]]
-      }
-      const headers = { Range: `bytes=${resolvedRange[0]}-${resolvedRange[1]}` }
-      try {
-        const res = await fetch(url, { headers })
-        if (!res.ok || !res.body) {
-          console.warn(`failed to fetch ${url}: ${res.status} ${await res.text()}`)
-          continue
+  async (location, range) => {
+    let networkError
+
+    for (const site of location.site) {
+      for (const url of site.location) {
+        let resolvedRange = [site.range.offset, site.range.offset + site.range.length - 1]
+        if (range) {
+          const relRange = resolveRange(range, site.range.length)
+          resolvedRange = [site.range.offset + relRange[0], site.range.offset + relRange[1]]
         }
-        return { ok: new Blob(location.digest, res) }
-      } catch (err) {
-        networkError = new NetworkError(url, { cause: err })
+        const headers = { Range: `bytes=${resolvedRange[0]}-${resolvedRange[1]}` }
+        try {
+          const res = await fetch(url, { headers })
+          if (!res.ok || !res.body) {
+            console.warn(`failed to fetch ${url}: ${res.status} ${await res.text()}`)
+            continue
+          }
+          return { ok: new Blob(location.digest, res) }
+        } catch (err) {
+          networkError = new NetworkError(url, { cause: err })
+        }
       }
     }
-  }
 
-  return { error: networkError || new NotFoundError(location.digest) }
-}
+    return { error: networkError || new NotFoundError(location.digest) }
+  }
+)
 
 /** @implements {API.Blob} */
 class Blob {

--- a/src/locator/content-claims.js
+++ b/src/locator/content-claims.js
@@ -5,6 +5,7 @@ import { DigestMap, ShardedDAGIndex } from '@web3-storage/blob-index'
 import { fetchBlob } from '../fetcher/simple.js'
 import { NotFoundError } from '../lib.js'
 import { base58btc } from 'multiformats/bases/base58'
+import { withSimpleSpan } from 'src/tracing/tracing.js'
 
 /**
  * @import { DID } from '@ucanto/interface'
@@ -78,7 +79,7 @@ export class ContentClaimsLocator {
    * Read claims for the passed CID and populate the cache.
    * @param {API.MultihashDigest} digest
    */
-  async #readClaims (digest) {
+  async #internalReadClaims (digest) {
     if (this.#claimFetched.has(digest)) return
 
     const claims = await Claims.read(digest, { serviceURL: this.#serviceURL })
@@ -110,7 +111,7 @@ export class ContentClaimsLocator {
           if (this.#carpark === undefined) {
             continue
           }
-          const obj = await this.#carpark.get(toBlobKey(claim.index.multihash))
+          const obj = await withSimpleSpan('carPark.get', this.#carpark.get, this.#carpark)(toBlobKey(claim.index.multihash))
           if (!obj) {
             continue
           }
@@ -169,6 +170,12 @@ export class ContentClaimsLocator {
     }
     this.#claimFetched.set(digest, true)
   }
+
+  /**
+   * Read claims for the passed CID and populate the cache.
+   * @param {API.MultihashDigest} digest
+   */
+  #readClaims = withSimpleSpan('readClaims', this.#internalReadClaims, this)
 
   /** @type {API.Locator['scopeToSpaces']} */
   scopeToSpaces (spaces) {

--- a/src/locator/content-claims.js
+++ b/src/locator/content-claims.js
@@ -5,7 +5,7 @@ import { DigestMap, ShardedDAGIndex } from '@web3-storage/blob-index'
 import { fetchBlob } from '../fetcher/simple.js'
 import { NotFoundError } from '../lib.js'
 import { base58btc } from 'multiformats/bases/base58'
-import { withSimpleSpan } from 'src/tracing/tracing.js'
+import { withSimpleSpan } from '../tracing/tracing.js'
 
 /**
  * @import { DID } from '@ucanto/interface'

--- a/src/tracing/tracing.js
+++ b/src/tracing/tracing.js
@@ -1,0 +1,69 @@
+import { trace, context, SpanStatusCode } from '@opentelemetry/api'
+
+/**
+ * @template {unknown[]} A
+ * @template {unknown} T
+ * @template {Error} X
+ * @template {import('../api.js').Result<T, X>} Result
+ * @param {string} spanName
+ * @param {(...args: A) => Promise<Result>} fn
+ */
+export const withResultSpan = (spanName, fn) =>
+  /**
+   * @param {A} args
+  */
+  async (...args) => {
+    const tracer = trace.getTracer('blob-fetcher')
+    const span = tracer.startSpan(spanName)
+    const ctx = trace.setSpan(context.active(), span)
+
+    const result = await context.with(ctx, fn, null, ...args)
+    if (result.ok) {
+      span.setStatus({ code: SpanStatusCode.OK })
+    } else {
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: result.error?.message
+      })
+    }
+    span.end()
+    return result
+  }
+
+/**
+ * @template {unknown[]} A
+ * @template {*} T
+ * @template {*} This
+ * @param {string} spanName
+ * @param {(this: This, ...args: A) => Promise<T>} fn
+ * @param {This} [thisParam]
+ */
+export const withSimpleSpan = (spanName, fn, thisParam) =>
+  /**
+   * @param {A} args
+  */
+  async (...args) => {
+    const tracer = trace.getTracer('blob-fetcher')
+    const span = tracer.startSpan(spanName)
+    const ctx = trace.setSpan(context.active(), span)
+
+    try {
+      const result = await context.with(ctx, fn, thisParam, ...args)
+      span.setStatus({ code: SpanStatusCode.OK })
+      span.end()
+      return result
+    } catch (err) {
+      if (err instanceof Error) {
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: err.message
+        })
+      } else {
+        span.setStatus({
+          code: SpanStatusCode.ERROR
+        })
+      }
+      span.end()
+      throw err
+    }
+  }

--- a/src/tracing/tracing.js
+++ b/src/tracing/tracing.js
@@ -31,6 +31,81 @@ export const withResultSpan = (spanName, fn) =>
   }
 
 /**
+ * @template {unknown} O
+ * @template {Error} X
+ * @template {unknown} T
+ * @template {import('../api.js').Result<O, X>} Result
+ * @param {import('@opentelemetry/api').Span} span
+ * @param {AsyncGenerator<T, Result>} gen
+ */
+async function * recordAsyncGeneratorSpan (span, gen) {
+  try {
+    for (;;) {
+      const { value: result, done } = await gen.next()
+      if (done) {
+        if (result.ok) {
+          span.setStatus({ code: SpanStatusCode.OK })
+        } else {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: result.error?.message
+          })
+        }
+        return result
+      }
+      yield (result)
+    }
+  } finally {
+    span.end()
+  }
+}
+
+/**
+ * @template {unknown[]} A
+ * @template {unknown} O
+ * @template {Error} X
+ * @template {unknown} T
+ * @template {import('../api.js').Result<O, X>} Result
+ * @param {string} spanName
+ * @param {(...args: A) => AsyncGenerator<T, Result>} fn
+ */
+export function withAsyncGeneratorSpan (spanName, fn) {
+  /**
+   * @param {A} args
+  */
+  return function (...args) {
+    const tracer = trace.getTracer('blob-fetcher')
+    const span = tracer.startSpan(spanName)
+    const ctx = trace.setSpan(context.active(), span)
+    const gen = context.with(ctx, fn, null, ...args)
+    return recordAsyncGeneratorSpan(span, bindAsyncGenerator(ctx, gen))
+  }
+}
+
+/**
+ * bindAsyncGenerator binds an async generator to a context
+ * see https://github.com/open-telemetry/opentelemetry-js/issues/2951
+ * @template {unknown} T
+ * @template {any} TReturn
+ * @template {unknown} TNext
+ * @param {import('@opentelemetry/api').Context} ctx
+ * @param {AsyncGenerator<T, TReturn, TNext>} generator
+ * @returns {AsyncGenerator<T, TReturn, TNext>}
+ */
+function bindAsyncGenerator (ctx, generator) {
+  return {
+    next: context.bind(ctx, generator.next.bind(generator)),
+    return: context.bind(ctx, generator.return.bind(generator)),
+    throw: context.bind(ctx, generator.throw.bind(generator)),
+
+    [Symbol.asyncIterator] () {
+      return bindAsyncGenerator(ctx, generator[Symbol.asyncIterator]())
+    },
+    [Symbol.asyncDispose]: context.bind(ctx, generator[Symbol.asyncDispose]?.bind(generator))
+  }
+}
+
+/**
  * @template {unknown[]} A
  * @template {*} T
  * @template {*} This


### PR DESCRIPTION
# Goals

First pass to optimize TTFB and bandwidth on the batching fetcher

# Implementation

see https://www.notion.so/storacha/Notes-on-Gateway-optimization-15c5305b55248022ad9be861df4899fb?pvs=4

The final algorithm that I settled on, which balances resource usage with optimal TTFB & bandwidth, is as follows:
- during a batch fetch, return blocks to the caller as soon as they are available (previously, the entire batch would need to be processed before any blocks are returned to the caller)
- remove multipart range requests, opting for a single range request that covers the entire batch. this may potentially grab a few extra bytes, but multipart range request support varies a lot server to server, and I'd rather not require it as we move into a decentralized world.
- when multiple batch requests are present at the same time, queue them up as follows:
   - make a request
   - as soon as first byte is received, kick off the next request while processing the response body of the first request
   - iterate through batches but make sure you only have at most two requests that are processing blocks (so memory usage is never more than batch size * 2). IOW, if you have received first byte on 2 requests, do not kick off any more until at least one finishes processing.
   - this should produce a steady stream of blocks that can be processed as fast as any client can handle
   - implementing this algorithm does require the use of async generators
 - this also adds some helpful tracing helpers. I'm not sure if these should live in this library though.
 
 # For discussion
 
 Future suggestion: freeway should be a monorepo, and this should be part of freeway.
 
 Final trace:
![Screenshot 2025-01-03 at 8 42 11 PM](https://github.com/user-attachments/assets/e59698b8-8631-437a-ae5d-3befeb6105e4)
 