### PR TITLE
feat(fetcher): allow passing a custom fetch implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,10 @@
     "./locator/indexing-service": {
       "import": "./src/locator/indexing-service/index.js",
       "types": "./dist/src/locator/indexing-service/index.d.ts"
+    },
+    "./tracing/tracing": {
+      "import": "./src/tracing/tracing.js",
+      "types": "./dist/src/tracing/tracing.d.ts"
     }
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-storage/blob-fetcher",
-  "version": "2.4.3",
+  "version": "2.4.4-rc.0",
   "description": "A blob fetcher that batches requests and reads multipart byterange responses.",
   "main": "src/index.js",
   "type": "module",


### PR DESCRIPTION
# Goals

Support the ability to intercept requests to CARPARK urls and replace them with direct R2 gets in Freeway (see https://github.com/storacha/freeway/pull/141)

# Implementation

allows simple & batching fetchers to use a custom fetch implementation. also exposes tracing library.

